### PR TITLE
fix: spacing between account-menu and minimize

### DIFF
--- a/src/css/steam/titlebar.css
+++ b/src/css/steam/titlebar.css
@@ -27,7 +27,7 @@
     display: flex;
 }
 .bSKGlAJG2UVWTsntEJY2v {
-    font-size: 0px;
+    font-size: 0;
 }
 .bSKGlAJG2UVWTsntEJY2v::after {
     display: flex;
@@ -73,7 +73,7 @@
     left: 50%;
     width: fit-content;
     height: 46px;
-    padding: 0px;
+    padding: 0;
     transform: translate(-50%, -50%);
 }
 ._3Z3ohQ8-1NKnCZkbS6fvy ._7AlhCx3XGzBeIrQaCneUD {
@@ -101,7 +101,7 @@
 
 
 ._3cykd-VfN_xBxf3Qxriccm {
-    margin: 0 0 0 10px;
+    margin: 0 27px 0 10px;
 }
 
 


### PR DESCRIPTION
### **Description:**
Changed the spacing between account menu and minimize button.
Aligned the spacing to the border of the minimize button and added additional 8px (green box in Screenshot 2) which is the spacing between account-menu and notifications button to have a overall cleaner look when hovering over the minimize button.

### **Screenshots:**
**OLD:**
![old_spacing_acc_menu_to_minimize](https://github.com/user-attachments/assets/4aff290d-c06e-47a0-b86a-87808158fb1e)
**NEW:**
![new_spacing_acc_menu_to_minimize](https://github.com/user-attachments/assets/571a3cd0-7b76-437f-bdd5-f5cde944160c)
