### PR TITLE
fix: window controls hidden when chat is docked to friendlist

### DIFF
--- a/friends.custom.css
+++ b/friends.custom.css
@@ -21,7 +21,7 @@
 
 .friendsListContainer,
 .multiChatDialog {
+    overflow: unset !important;
     height: calc(100% - 48px);
     margin: 32px 16px 16px;
-    overflow: unset !important;
 }

--- a/friends.custom.css
+++ b/friends.custom.css
@@ -23,4 +23,5 @@
 .multiChatDialog {
     height: calc(100% - 48px);
     margin: 32px 16px 16px;
+    overflow: unset !important;
 }


### PR DESCRIPTION
### **Description**

When the chat window is docked to the friend list, the window controls were hidden behind the chat window.

**Before:**
![grafik](https://github.com/user-attachments/assets/2763cf7e-b751-40c3-81ec-e8e7ffe07534)


**After:**
![grafik](https://github.com/user-attachments/assets/6082fc5f-b6dd-4726-9b56-2b15b41d3456)

