### PR TITLE
More overlay menus themeable

### DIFF
--- a/libraryroot.custom.css
+++ b/libraryroot.custom.css
@@ -5,6 +5,10 @@
 @import url("./src/css/steam/gamepage.css");
 @import url("./src/css/steam/downloadPage.css");
 @import url("./src/css/steam/newsModal.css");
+@import url("./src/css/overlay/overview.css");
+@import url("./src/css/overlay/clock.css");
+@import url("./src/css/overlay/guide.css");
+@import url("./src/css/overlay/recordings.css");
 
 
 /* Base */

--- a/src/css/overlay/clock.css
+++ b/src/css/overlay/clock.css
@@ -1,0 +1,16 @@
+.C9tvuqqEXGcrkcAtHrQ_R {
+    background: rgb(var(--background));
+}
+.HijmccPB1BKyhOwhX1EVl {
+    border-radius: 8px;
+    background-color: rgb(var(--color-2));
+}
+.HijmccPB1BKyhOwhX1EVl._3-_jME_xsuvgT3Dvq4bw_q, .HijmccPB1BKyhOwhX1EVl._3-_jME_xsuvgT3Dvq4bw_q:hover {
+    background: rgb(var(--accent-1));
+}
+.DialogSlider_Value {
+    background: rgb(var(--accent-1));
+}
+.DialogSlider_Grabber {
+    background: rgb(var(--accent-2));
+}

--- a/src/css/overlay/guide.css
+++ b/src/css/overlay/guide.css
@@ -1,0 +1,2 @@
+.C9tvuqqEXGcrkcAtHrQ_R {
+    background: rgb(var(--background));

--- a/src/css/overlay/overview.css
+++ b/src/css/overlay/overview.css
@@ -1,0 +1,20 @@
+/* Game Overview */
+.C9tvuqqEXGcrkcAtHrQ_R {
+    background: rgb(var(--background));
+}
+._27m9Qbg4ShilOgwvYZWV8l {
+    background: rgb(var(--background));
+}
+._27m9Qbg4ShilOgwvYZWV8l ._1vG-vFfwpDeNStVbyo1Qy6.P46KVvNDqOUONCIHBwKgU {
+    background-color: rgb(var(--color-2));
+    border-radius: 8px;
+}
+._27m9Qbg4ShilOgwvYZWV8l ._1vG-vFfwpDeNStVbyo1Qy6 ._2wBK7MqJSrj6QCxf3357yL {
+    background-color: rgb(var(--color-2));
+}
+._27m9Qbg4ShilOgwvYZWV8l ._1vG-vFfwpDeNStVbyo1Qy6 ._2OwqXw1nhBL430bsYTeEr- {
+    background-color: rgb(var(--color-2));
+}
+._27m9Qbg4ShilOgwvYZWV8l ._1vG-vFfwpDeNStVbyo1Qy6 ._3eNE5TKtDTnfNBAsCqfcP0 {
+    background-color: rgb(var(--color-2));
+}

--- a/src/css/overlay/recordings.css
+++ b/src/css/overlay/recordings.css
@@ -1,0 +1,28 @@
+.C9tvuqqEXGcrkcAtHrQ_R {
+    background: rgb(var(--background));
+}
+
+._1f9_BgoyE1cjqyeKD8dh9u .YzIcpcz4oFx-nndxro5jE {
+    background: rgb(var(--color-2));
+    border: 0px solid;
+    border-image-source: linear-gradient(to right, rgba(71, 78, 86, 0.5) 20%, rgba(71, 78, 86, 0.2) 50%);
+}
+._1f9_BgoyE1cjqyeKD8dh9u .YzIcpcz4oFx-nndxro5jE .hXJt8CFzzitOG3moJEGg- {
+    color: rgb(var(--accent-1));
+}
+._2T45kYJmyvQWyxytQeohuY._3JYigpIF46lZDATkhxHZmZ {
+    background-color: rgb(var(--accent-1));
+}
+._2OsQkIMNf9Cnl4xfBXMApr {
+    background-color: rgb(var(--background));
+}
+.uCBCZOATxD3vzPCGUgDEp {
+    background-color: rgb(var(--color-2));
+    border-radius: 8px;
+}
+._1f9_BgoyE1cjqyeKD8dh9u .YzIcpcz4oFx-nndxro5jE .hXJt8CFzzitOG3moJEGg- {
+    color: rgb(var(--accent-1));
+}
+._36KTbApKz0VLY9Q6lGt4aH {
+    background-color: rgb(var(--background));
+}


### PR DESCRIPTION
adds theme support for the clock, overview, and screenshots popup in the overlay
also adds a titlebar background for the overlay browsers including guides, discussions, DLC, and web browser everything is linked to the background and accent colors in the theme settings