### PR TITLE
fix playbar container background and tweak category header

### DIFF
--- a/src/css/steam/gamepage.css
+++ b/src/css/steam/gamepage.css
@@ -124,6 +124,7 @@
 
 
 ._3DeO92O5aVkcdwEBCJDjWm._3fLo166MlaNqP8r8tTyRz {
+    background: none !important;
     margin-bottom: 0;
     background: unset;
 }

--- a/src/css/steam/gamepage.css
+++ b/src/css/steam/gamepage.css
@@ -124,7 +124,7 @@
 
 
 ._3DeO92O5aVkcdwEBCJDjWm._3fLo166MlaNqP8r8tTyRz {
-    background: none !important;
+    background: unset !important;
     margin-bottom: 0;
 }
 

--- a/src/css/steam/gamepage.css
+++ b/src/css/steam/gamepage.css
@@ -126,7 +126,6 @@
 ._3DeO92O5aVkcdwEBCJDjWm._3fLo166MlaNqP8r8tTyRz {
     background: none !important;
     margin-bottom: 0;
-    background: unset;
 }
 
 ._3Y87YQY56ZCOqhgcZFaDc5 {

--- a/src/css/steam/sidebar.css
+++ b/src/css/steam/sidebar.css
@@ -233,20 +233,20 @@
     background: none;
     background-color: rgb(var(--color-1));
     align-items: center;
-  }
+}
 
-  ._2sYIghGVXJr6tsQVvcryy8 ._3SFRZYIb9Y2q7YsVtB3YKb,
-  ._2sYIghGVXJr6tsQVvcryy8 ._2mZ8LlvoUiyeEUtIWuTri {
-      height: unset;
-  }
+._2sYIghGVXJr6tsQVvcryy8 ._3SFRZYIb9Y2q7YsVtB3YKb,
+._2sYIghGVXJr6tsQVvcryy8 ._2mZ8LlvoUiyeEUtIWuTri {
+    height: unset;
+}
 
-  ._2sYIghGVXJr6tsQVvcryy8 ._3SFRZYIb9Y2q7YsVtB3YKb {
-      margin-top: 1px;
-  }
+._2sYIghGVXJr6tsQVvcryy8 ._3SFRZYIb9Y2q7YsVtB3YKb {
+    margin-top: 1px;
+}
 
-  ._2sYIghGVXJr6tsQVvcryy8 ._29uten9Yy8q-n7woDEOXVF {
-    margin-top: -1px;
-  }
+._2sYIghGVXJr6tsQVvcryy8 ._29uten9Yy8q-n7woDEOXVF {
+  margin-top: -1px;
+}
 
 
 /* Game item */

--- a/src/css/steam/sidebar.css
+++ b/src/css/steam/sidebar.css
@@ -232,7 +232,21 @@
     border-radius: 8px;
     background: none;
     background-color: rgb(var(--color-1));
-}
+    align-items: center;
+  }
+
+  ._2sYIghGVXJr6tsQVvcryy8 ._3SFRZYIb9Y2q7YsVtB3YKb,
+  ._2sYIghGVXJr6tsQVvcryy8 ._2mZ8LlvoUiyeEUtIWuTri {
+      height: unset;
+  }
+
+  ._2sYIghGVXJr6tsQVvcryy8 ._3SFRZYIb9Y2q7YsVtB3YKb {
+      margin-top: 1px;
+  }
+
+  ._2sYIghGVXJr6tsQVvcryy8 ._29uten9Yy8q-n7woDEOXVF {
+    margin-top: -1px;
+  }
 
 
 /* Game item */

--- a/src/css/steam/sidebar.css
+++ b/src/css/steam/sidebar.css
@@ -245,7 +245,7 @@
 }
 
 ._2sYIghGVXJr6tsQVvcryy8 ._29uten9Yy8q-n7woDEOXVF {
-  margin-top: -1px;
+    margin-top: -1px;
 }
 
 


### PR DESCRIPTION
# Changes made
- Fixed the blue gray peeking from behind the top left corner
- Improved the text alignment of category headers
- Improved the hovering of long category header names (by complete accident)

## Before
![Play Bar Container Before](https://github.com/user-attachments/assets/83a62277-acbb-49a4-99e1-6e433fd71382)
Slight blue gray peaking out from top left corner

![Category Header Before](https://github.com/user-attachments/assets/d12c0da0-6645-4a47-9cdb-0d59e05d03e4)
The name of the category sits way too high and looks out of place

![Category Header Hover Before](https://github.com/user-attachments/assets/0b6376f2-1373-4df3-8c15-7cb4cc0b73d6)
The background of the category name peaks out from under the category name hover background

## After
![Play Bar Container After](https://github.com/user-attachments/assets/4325533a-c238-493a-9690-0c2bfdf33ac3)
![Play Bar Container Hover After](https://github.com/user-attachments/assets/0ba62fa8-e6a9-4c9d-b39f-7c8d844dce69)
![Category Header After](https://github.com/user-attachments/assets/ba05ae8c-9901-42d2-a334-0bfd65012d5a)
