### PR TITLE
Removes white space in game profile

### DIFF
--- a/src/css/webkit/game.css
+++ b/src/css/webkit/game.css
@@ -1,6 +1,5 @@
 body.v6.game_bg.application .page_content_ctn,
 body.v6.game_bg.application .page_content {
-    width: 1260px;
     margin: 0 auto;
 }
 
@@ -51,7 +50,7 @@ body.v6.game_bg.application .page_content {
 .game_bg.application .queue_overflow_ctn {
     position: absolute;
     top: -48px;
-    right: 0;
+    right: 310px;
 }
 
 .game_bg.application .queue_overflow_ctn .queue_ctn {


### PR DESCRIPTION
Hello! First time contributor here! Thanks for creating the theme, I did notice that there was a lot of white (wasted? space between the left and right columns. Was curious if it was intentional, it did look off at 100% magnification on a 4K monitor/resolution. Thanks!

## Before
![Screenshot 2025-03-21 203117](https://github.com/user-attachments/assets/3c2b09f1-6e72-4b98-b63e-cd06abca160b)

## After
![Screenshot 2025-03-21 204809](https://github.com/user-attachments/assets/ba17d403-1b0a-4a45-a71b-c003ed608a46)
