### PR TITLE
fix: correctly center collection header content in sidebar

### DIFF
--- a/src/css/steam/sidebar.css
+++ b/src/css/steam/sidebar.css
@@ -245,11 +245,9 @@
 }
 
 ._2sYIghGVXJr6tsQVvcryy8 ._3SFRZYIb9Y2q7YsVtB3YKb {
-    margin-top: 1px;
-}
-
-._2sYIghGVXJr6tsQVvcryy8 ._29uten9Yy8q-n7woDEOXVF {
-    margin-top: -1px;
+    display: flex;
+    align-items: center;
+    padding: 0 2px 0 4px;
 }
 
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/494b2412-c319-4527-8c09-8215e67994e5)


After:
![image](https://github.com/user-attachments/assets/1e43e1f6-ffbf-48ff-9ed5-2222f93270d8)
