### PR TITLE
Changed behavior for "Gamepage bigger banner" so it shows full image.

### DIFF
--- a/options/general/gamepageBiggerBanner.css
+++ b/options/general/gamepageBiggerBanner.css
@@ -1,33 +1,15 @@
 .NZMJ6g2iVnFsOOp-lDmIP {
-    --header-height: calc(100vh - 46px - 16px - 12px - 70px - 6px - 40px - 16px - 16px - 50px - 16px) !important;
-    max-height: unset !important;
+    overflow: hidden !important;
+    width: 100%;
+    height: auto !important;
+    min-height: 150px;
+    max-height: none !important;
+    margin-bottom: 12px;
 }
-._1SvpjsckP9cPRxO6gCBHrw:has(._1_cYNJSvS6IXs9vLTEYjy5 .z8GYwNt_nbBZrf7OVjs-s) .NZMJ6g2iVnFsOOp-lDmIP {
-    --header-height: calc(100vh - 46px - 16px - 12px - 70px - 6px - 40px - 16px - 16px - 46px) !important;
-}
-.NarrowWindow .NZMJ6g2iVnFsOOp-lDmIP {
-    --header-height: calc(100vh - 46px - 16px - 12px - 56px - 6px - 40px - 16px - 16px - 50px - 16px) !important;
-}
-.NarrowWindow ._1SvpjsckP9cPRxO6gCBHrw:has(._1_cYNJSvS6IXs9vLTEYjy5 .z8GYwNt_nbBZrf7OVjs-s) .NZMJ6g2iVnFsOOp-lDmIP {
-    --header-height: calc(100vh - 46px - 16px - 12px - 56px - 6px - 40px - 16px - 16px - 50px - 16px - 46px) !important;
-}
-
-
-:has(.userpannel-buttoncontainer) .NZMJ6g2iVnFsOOp-lDmIP {
-    --header-height: calc(100vh - 46px - 16px - 12px - 70px - 6px - 40px - 16px - 16px) !important;
-    max-height: unset !important;
-}
-:has(.userpannel-buttoncontainer) ._1SvpjsckP9cPRxO6gCBHrw:has(._1_cYNJSvS6IXs9vLTEYjy5 .z8GYwNt_nbBZrf7OVjs-s) .NZMJ6g2iVnFsOOp-lDmIP {
-    --header-height: calc(100vh - 46px - 16px - 12px - 70px - 6px - 40px - 16px - 16px - 46px) !important;
-}
-:has(.userpannel-buttoncontainer) .NarrowWindow .NZMJ6g2iVnFsOOp-lDmIP {
-    --header-height: calc(100vh - 46px - 16px - 12px - 56px - 6px - 40px - 16px - 16px) !important;
-}
-:has(.userpannel-buttoncontainer) .NarrowWindow ._1SvpjsckP9cPRxO6gCBHrw:has(._1_cYNJSvS6IXs9vLTEYjy5 .z8GYwNt_nbBZrf7OVjs-s) .NZMJ6g2iVnFsOOp-lDmIP {
-    --header-height: calc(100vh - 46px - 16px - 12px - 56px - 6px - 40px - 16px - 16px - 46px) !important;
-}
-
-
-.NZMJ6g2iVnFsOOp-lDmIP.NZMJ6g2iVnFsOOp-lDmIP ._1IX7FPSY9Jb82KhBVBSkZa {
-    max-height: unset !important;
+._1IX7FPSY9Jb82KhBVBSkZa {
+    width: 100%;
+    height: auto !important;
+    min-height: 150px;
+    max-height: none !important;
+    transform: none !important;
 }

--- a/skin.json
+++ b/skin.json
@@ -1,6 +1,6 @@
 {
     "version": "20250524",
-    "name": "SpaceTheme for Steam",
+    "name": "SpaceTheme for Steam 20250524",
     "description": "A modular design with dark colors intended to enhance navigability and improve user experience.",
     "author": "SpaceEnergy",
     "github": {
@@ -17,7 +17,7 @@
     "UseDefaultPatches": true,
     "Conditions": {
         "Gamepage bigger banner": {
-            "description": "Bigger banner on the game page",
+            "description": "No cropped banner on the game page",
             "default": "no",
             "tab": "General",
             "values": {

--- a/skin.json
+++ b/skin.json
@@ -1,6 +1,6 @@
 {
     "version": "20250524",
-    "name": "SpaceTheme for Steam 20250524",
+    "name": "SpaceTheme for Steam",
     "description": "A modular design with dark colors intended to enhance navigability and improve user experience.",
     "author": "SpaceEnergy",
     "github": {
@@ -16,7 +16,7 @@
     "Steam-WebKit": "webkit.css",
     "UseDefaultPatches": true,
     "Conditions": {
-        "Gamepage bigger banner": {
+        "Gamepage banner no crop": {
             "description": "No cropped banner on the game page",
             "default": "no",
             "tab": "General",

--- a/src/css/steam/gamepage.css
+++ b/src/css/steam/gamepage.css
@@ -19,13 +19,13 @@
 & Gamepage Banner
 */
 .NZMJ6g2iVnFsOOp-lDmIP {
-    overflow: hidden !important;
-    max-height: 420px !important;
+    overflow: hidden;
+    max-height: 420px;
     margin-bottom: 12px;
 }
 ._1IX7FPSY9Jb82KhBVBSkZa {
-    max-height: 420px !important;
-    transform: none !important;
+    max-height: 420px;
+    transform: none;
 }
 
 .QlR9EFwTdUNm_J5vx54_Z {


### PR DESCRIPTION
Changed behavior for "Gamepage bigger banner" so it ALWAYS shows the full image (official or custom artwork).

The code had a couple errors (it wouldn't implement the option changes correctly because it had **"!important"** on both places _[gamepage.css and gamepageBiggerBanner.css]_) and even then, it would just make it bigger but massively cropping the image and it also had an alignment issue as seen below.

![image](https://github.com/user-attachments/assets/cde36370-0dbd-4201-ac19-cef2578076ae)

Now it makes it so the image displays fully (does not matter aspect ratio or pixel size) and without any crop on any side (also correctly aligned)

Original image by Larian Studios
![image](https://github.com/user-attachments/assets/e67df4db-20da-4bfc-9d29-6b3beae0ca39)

Custom image with different aspect ratio
![image](https://github.com/user-attachments/assets/df4dfaf1-55a9-4419-9ab5-3660da3941d2)