### PR TITLE
change: logo takes accent color

### DIFF
--- a/src/css/steam/titlebar.css
+++ b/src/css/steam/titlebar.css
@@ -73,14 +73,14 @@
     content: "Space" !important;
     font-weight: 500;
     font-size: 12px !important;
-    color: rgb(135, 140, 255);
+    color: rgb(var(--accent-2));
 }
 ._2UyOBeiSdBayaFdRa39N2O:nth-of-type(1)::after {
     display: flex;
     align-items: center;
     content: "Theme" !important;
     font-weight: 900;
-    color: rgb(102, 108, 255);
+    color: rgb(var(--accent-1));
 }
 
 


### PR DESCRIPTION
Made a change so that when you change accent colors on the skin, it also affects the "SpaceTheme" logo on the titlebar, becoming more consistent.

Logo with default colors
![image](https://github.com/user-attachments/assets/7c9ca27a-b46c-49f9-8006-0917703a0d8a)


Logo with accent colors
![image](https://github.com/user-attachments/assets/022ba4a9-084a-47fd-8474-f675431d21c8)