### PR TITLE
Added option for Dynamic Banner Height

### DIFF
--- a/options/library/gamepage/dynamicBannerHeight.css
+++ b/options/library/gamepage/dynamicBannerHeight.css
@@ -1,0 +1,4 @@
+/* Remove the fixed banner cap so banner height scales with available width. */
+body {
+    --st-gamepage-banner-max-height: none;
+}

--- a/skin.json
+++ b/skin.json
@@ -505,6 +505,20 @@
                 }
             }
         },
+
+
+        "Library - Dynamic banner height": {
+            "description": "Scale gamepage banner height with window size to preserve full banner aspect ratio",
+            "default": "no",
+            "tab": "Library",
+            "section": "Gamepage",
+            "values": {
+                "no": {},
+                "yes": {
+                    "TargetCss": { "affects": ["^Steam$"], "src": "options/library/gamepage/dynamicBannerHeight.css" }
+                }
+            }
+        },
         
 
         "Library - Banner Infos": {

--- a/src/css/steam/gamepage.css
+++ b/src/css/steam/gamepage.css
@@ -23,11 +23,11 @@
 */
 .NZMJ6g2iVnFsOOp-lDmIP {
     overflow: hidden !important;
-    max-height: 420px !important;
+    max-height: var(--st-gamepage-banner-max-height, 420px) !important;
     margin-bottom: 12px;
 }
 ._1IX7FPSY9Jb82KhBVBSkZa {
-    max-height: 420px !important;
+    max-height: var(--st-gamepage-banner-max-height, 420px) !important;
     transform: none !important;
 }
 


### PR DESCRIPTION
When this option is enabled within the library, the height of the banner within the game page is allowed to scale dynamically to ensure that the full image is displayed at all times without letterboxing or cropping.