### PR TITLE
fix library button colors

### DIFF
--- a/src/css/steam/libHome.css
+++ b/src/css/steam/libHome.css
@@ -322,13 +322,13 @@
     background: rgb(var(--st-blue));
 }
 ._3AjoLnMNKxYmNTGTJCLfgs._3VOR2AeYATx3qSE0I-Pm-5:hover {
-    background: rgb(var(--st-blue-hover));
+    background: rgb(var(--st-blue-hover)) !important;
 }
 ._3AjoLnMNKxYmNTGTJCLfgs._1_Bo2Ied5s2Od4YKYTOsau:not(._1aml4h4CSJbtrNbX4brUYs) {
-    background: rgb(var(--st-green));
+    background: rgb(var(--st-green)) !important;
 }
 ._3AjoLnMNKxYmNTGTJCLfgs._1_Bo2Ied5s2Od4YKYTOsau:not(._1aml4h4CSJbtrNbX4brUYs):hover {
-    background: rgb(var(--st-green-hover));
+    background: rgb(var(--st-green-hover)) !important;
 }
 
 /* Info */


### PR DESCRIPTION
For some reason these buttons have bgs set with very high specificity, either (0,5,0) or (0,6,0). At this point I'd rather just put `!important` in here.

<img width="311" height="142" alt="image" src="https://github.com/user-attachments/assets/75d22a9a-0fef-4301-b874-327799059e9e" />